### PR TITLE
Fix noarch builds

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -12,8 +12,6 @@ build:
     number: {{ git_revision_count }}
     script: python setup.py install
     noarch: python
-    ignore_run_exports:
-        - python_abi
 
 requirements:
 

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -19,7 +19,7 @@ requirements:
 
     # The runtime deps are also needed for build because setup.py lists them and
     # will try to download from pypi during the build step if not installed.
-    build:
+    host:
         - python
         - setuptools
         - pytest-benchmark=3.2.3

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -6,14 +6,14 @@ package:
     version: {{ version }}
 
 source:
-    # Actual git_url is: https://github.com/rapidsai/benchmark.git, but using a
-    # relative path to build from sources here.
     path: ..
 
 build:
     number: {{ git_revision_count }}
     script: python setup.py install
     noarch: python
+    ignore_run_exports:
+        - python_abi
 
 requirements:
 


### PR DESCRIPTION
This PR is intended to fix the `noarch` builds. Please see my screenshot below for local test results.

EDIT ---

This PR didn't actually fix `noarch` builds. Updating `conda-build` is what resolved the `noarch` issues. See comments below. 