### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,9 @@ Here are some guidelines to help the review process go smoothly.
    features or make changes out of the scope of those requested by the reviewer
    (doing this just add delays as already reviewed code ends up having to be
    re-reviewed/it is hard to tell what is new etc!). Further, please do not
-   rebase your branch on master/force push/rewrite history, doing any of these
+   rebase your branch on main/force push/rewrite history, doing any of these
    causes the context of any comments made by reviewers to be lost. If
-   conflicts occur against master they should be resolved by merging master
+   conflicts occur against main they should be resolved by merging main
    into the branch used for making the pull request.
 
 Many thanks in advance for your cooperation!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ with this before spending time on a contribution.
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/benchmark/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/benchmark/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/benchmark/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/benchmark/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -46,8 +46,8 @@ In no particular order, this covers implementation details and common maintenanc
 
 
 ## ops-utils repo tools
-- For convenience, the benchmark jobs use tools in the [`ops-utils` repo](https://github.com/rapidsai/ops-utils/tree/master/benchmark), in particular the `updateJenkinsReport.py` script for creating the nightly overview report.
-- Another useful script in this repo is one which can return the exact nightly conda package that was used with a particular commit, called [getNearestCondaPackages.py](https://github.com/rapidsai/ops-utils/blob/master/benchmark/getNearestCondaPackages.py)
+- For convenience, the benchmark jobs use tools in the [`ops-utils` repo](https://github.com/rapidsai/ops-utils/tree/main/benchmark), in particular the `updateJenkinsReport.py` script for creating the nightly overview report.
+- Another useful script in this repo is one which can return the exact nightly conda package that was used with a particular commit, called [getNearestCondaPackages.py](https://github.com/rapidsai/ops-utils/blob/main/benchmark/getNearestCondaPackages.py)
 
 
 ## Jenkins jobs overview

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ TBD
 ## Using asvdb from python and the command line
 [`asvdb`](https://github.com/rapidsai/asvdb) is a library and command-line utility for reading and writing benchmark results from/to an ASV "database" as described [here](https://asv.readthedocs.io/en/stable/dev.html?highlight=%24results_dir#benchmark-suite-layout-and-file-formats).
 * `asvdb` is a key component in the benchmark infrastructure suite in that it is the destination for benchmark results measured by the developer's benchmark code, and the source of data for the benchmarking report tools (in this case just ASV).
-* Several examples for both reading and writing a database using the CLI and the API are available [here](https://github.com/rapidsai/asvdb/blob/master/README.md)
+* Several examples for both reading and writing a database using the CLI and the API are available [here](https://github.com/rapidsai/asvdb/blob/main/README.md)
 
 
 ## Benchmarking old commits


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.