### PR TITLE
Add requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features
 
-- ...
+- PR #45 - Add capability to parse `requirements` metadata field
 
 ## Improvements
 

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
     number: {{ git_revision_count }}
-    script: python setup.py install
+    script: {{ PYTHON }} -m pip install . --no-deps
     noarch: python
 
 requirements:

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
     number: {{ git_revision_count }}
-    script: {{ PYTHON }} -m pip install . --no-deps
+    script: python setup.py install
     noarch: python
 
 requirements:

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -4,6 +4,7 @@ import platform
 import ctypes
 import argparse
 import subprocess
+import json
 
 import pytest
 from pytest_benchmark import stats as pytest_benchmark_stats
@@ -472,7 +473,7 @@ def pytest_sessionfinish(session, exitstatus):
         commitTime = asvMetadata.get("commitTime", commitTime)
         commitRepo = asvMetadata.get("commitRepo", commitRepo)
         commitBranch = asvMetadata.get("commitBranch", commitBranch)
-        requirements = asvMetadata.get("requirements")
+        requirements = json.loads(asvMetadata.get("requirements")) if "requirements" in asvMetadata else None
 
         suffixDict = dict(gpu_util="gpuutil",
                           gpu_mem="gpumem",

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -471,7 +471,7 @@ def pytest_sessionfinish(session, exitstatus):
         commitTime = asvMetadata.get("commitTime", commitTime)
         commitRepo = asvMetadata.get("commitRepo", commitRepo)
         commitBranch = asvMetadata.get("commitBranch", commitBranch)
-        requirements = json.loads(asvMetadata.get("requirements", "{}"))
+        requirements = asvMetadata.get("requirements", "{}")
 
         suffixDict = dict(gpu_util="gpuutil",
                           gpu_mem="gpumem",
@@ -501,9 +501,10 @@ def pytest_sessionfinish(session, exitstatus):
         for bench in gpuBenchSess.benchmarks:
             benchName = _getHierBenchNameFromFullname(bench.fullname)
             # build the final params dict by extracting them from the
-            # bench.params dictionary
+            # bench.params dictionary. Not all benchmarks are parameterized
             params = {}
-            for (paramName, paramVal) in bench.params.items():
+            bench_params = bench.params.items() if bench.params is not None else []
+            for (paramName, paramVal) in bench_params:
                 # If the params are coming from a fixture, handle them
                 # differently since they will (should be) stored in a special
                 # variable accessible with the name of the fixture.

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -472,6 +472,7 @@ def pytest_sessionfinish(session, exitstatus):
         commitTime = asvMetadata.get("commitTime", commitTime)
         commitRepo = asvMetadata.get("commitRepo", commitRepo)
         commitBranch = asvMetadata.get("commitBranch", commitBranch)
+        requirements = asvMetadata.get("requirements")
 
         suffixDict = dict(gpu_util="gpuutil",
                           gpu_mem="gpumem",
@@ -495,7 +496,8 @@ def pytest_sessionfinish(session, exitstatus):
                               cpuType=cpuType,
                               arch=arch,
                               ram=ram,
-                              gpuRam=gpuRam)
+                              gpuRam=gpuRam,
+                              requirements=requirements)
 
         for bench in gpuBenchSess.benchmarks:
             benchName = _getHierBenchNameFromFullname(bench.fullname)


### PR DESCRIPTION
This PR enables the `rapids-pytest-benchmark` plugin to parse `requirements` metadata if it's provided.


