### PR TITLE
Add psutil to conda-build

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -1,16 +1,14 @@
-{% set version = load_setup_py_data(setup_file='rapids_pytest_benchmark/setup.py').get('version') %}
-{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
+{% set version = load_setup_py_data().get('version') %}
 
 package:
     name: rapids-pytest-benchmark
     version: {{ version }}
 
 source:
-    path: ../../
+    path: ..
 
 build:
-    number: {{ git_revision_count }}
-    script: {{ PYTHON }} -m pip install ./rapids_pytest_benchmark --no-deps
+    script: {{ PYTHON }} -m pip install . --no-deps
     noarch: python
 
 requirements:
@@ -24,6 +22,7 @@ requirements:
         - pynvml
         - asvdb>=0.3.0
         - pygal
+        - psutil
 
 test:
     imports:

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = load_setup_py_data().get('version') %}
+{% set version = load_setup_py_data(setup_file='rapids_pytest_benchmark/setup.py').get('version') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
 
 package:
@@ -6,24 +6,17 @@ package:
     version: {{ version }}
 
 source:
-    path: ..
+    path: ../../
 
 build:
     number: {{ git_revision_count }}
-    script: python setup.py install
+    script: {{ PYTHON }} -m pip install ./rapids_pytest_benchmark --no-deps
     noarch: python
 
 requirements:
 
-    # The runtime deps are also needed for build because setup.py lists them and
-    # will try to download from pypi during the build step if not installed.
     host:
         - python
-        - setuptools
-        - pytest-benchmark=3.2.3
-        - pynvml
-        - asvdb>=0.3.0
-        - pygal
 
     run:
         - python

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 def setFixtureParamNames(request, orderedParamNameList):
     """


### PR DESCRIPTION
Closes #54.

This PR updates the `conda` recipe to include `psutil` since it was missing.

Additionally, it removes `git_revision_count`. `git_revision_count` doesn't work correctly here since the conda recipe _source path_ value doesn't point to the root directory of the project (`rapids_pytest_benchmark` is a sub-directory).

It also removes some `host` requirements, since they are not required.