### PR TITLE
[REVIEW] Use addResults instead of addResult

### DIFF
--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -531,7 +531,8 @@ def pytest_sessionfinish(session, exitstatus):
             bench.stats.mean
             getattr(bench.stats, "gpu_mem", None)
             getattr(bench.stats, "gpu_util", None)
-
+            
+            resultList = []
             for statType in ["mean", "gpu_mem", "gpu_util"]:
                 bn = "%s_%s" % (benchName, suffixDict[statType])
                 val = getattr(bench.stats, statType, None)
@@ -540,7 +541,9 @@ def pytest_sessionfinish(session, exitstatus):
                                               argNameValuePairs=list(params.items()),
                                               result=val)
                     bResult.unit = unitsDict[statType]
-                    db.addResult(bInfo, bResult)
+                    resultList.append(bResult)
+            
+            db.addResults(bInfo, resultList)
 
 
 def pytest_report_header(config):

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -430,9 +430,6 @@ def _getHierBenchNameFromFullname(benchFullname):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    if exitstatus != 0:
-        return
-
     gpuBenchSess = session.config._gpubenchmarksession
     config = session.config
     asvOutputDir = config.getoption("benchmark_asv_output_dir")


### PR DESCRIPTION
This change helps lower API calls when used with S3 functionality in asvDB.

Also removed exitstatus block to allow asvDB updates for any passing benchmarks.