### PR TITLE
[ENH] Initial version of new user API to add custom metrics

### DIFF
--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -159,6 +159,9 @@ class GPUStats(pytest_benchmark_stats.Stats):
     def __init__(self):
         super().__init__()
         self.gpuData = []
+        # Custom metrics are by:
+        #     key : name of the metric
+        #     value : tuple of (value, unit_type)
         self.__customMetrics = {}
 
 
@@ -280,12 +283,13 @@ class GPUBenchmarkFixture(pytest_benchmark_fixture.BenchmarkFixture):
 
 
     def _run_custom_measurements(self, function_result):
+        # Run custom metrics if they are enabled
         if self.enabled and not(self.customMetricsDisable):
-            for (metic_name, (metric_callable, metric_unit_string)) in \
+            for (metric_name, (metric_callable, metric_unit_string)) in \
                 self.__customMetricsDict.items():
                 self.stats.updateCustomMetric(
                     metric_callable(function_result),
-                    metic_name, metric_unit_string)
+                    metric_name, metric_unit_string)
 
 
     def _raw(self, function_to_benchmark, *args, **kwargs):


### PR DESCRIPTION
This is an initial working version of a new user API to add custom metrics to benchmarks.  This feature still needs the following to be considered complete:
- [x] README update with example
- [x] code cleanup (mostly better comments)
- [ ] update the console reporting to actually include the new metrics (right now, only ASV report will include them)
- [x] more testing

related: #38  (I don't know if this can close it or not)

Here's an example of how to use it:
```
def bench_bfs(gpubenchmark, anyGraphWithAdjListComputed):
    # This is where we'd call NetworkX.BFS and get its result for comparison
    networkXResult = 3
    def checkAccuracy(bfsResult):
        """
        This function will be called by the benchmarking framework and will be
        passed the result of the benchmarked function (in this case,
        cugraph.bfs).
        Compare that result to NetworkX.BFS()
        """
        s=0
        for d in bfsResult['distance'].values_host:
            s+=d
        r = float(s/len(bfsResult))

        result= abs(((r - networkXResult) / networkXResult) * 100)
        return result

    gpubenchmark.addMetric(checkAccuracy, "accuracy", "percent")
    gpubenchmark(cugraph.bfs, anyGraphWithAdjListComputed, 0)
```
