### PR TITLE
[REVIEW] Move RMM spec to host requirements

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = load_setup_py_data().get('version') %}
 
 package:
-    name: rapids-pytest-benchmark
+    name: rapids-pytest-benchmark-test
     version: {{ version }}
 
 source:
@@ -15,7 +15,7 @@ requirements:
 
     host:
         - python
-
+        - rmm>=0.19.0a
     run:
         - python
         - pytest-benchmark=3.2.3
@@ -23,7 +23,6 @@ requirements:
         - asvdb>=0.3.0
         - pygal
         - psutil
-        - rmm>=0.19.0a
 
 test:
     imports:

--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = load_setup_py_data().get('version') %}
 
 package:
-    name: rapids-pytest-benchmark-test
+    name: rapids-pytest-benchmark
     version: {{ version }}
 
 source:

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 
 def setFixtureParamNames(request, orderedParamNameList):
     """


### PR DESCRIPTION
This allows conda to solve using the preprovided rmm version from the host, resulting in not updating to a more recent rmm version when downloading.