### PR TITLE
[REVIEW] FIX Revert spec to runtime req

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -15,7 +15,6 @@ requirements:
 
     host:
         - python
-        - rmm>=0.19.0a
     run:
         - python
         - pytest-benchmark=3.2.3
@@ -23,6 +22,7 @@ requirements:
         - asvdb>=0.3.0
         - pygal
         - psutil
+        - rmm>=0.19.0a
 
 test:
     imports:

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.15"
+__version__ = "0.0.14"
 
 def setFixtureParamNames(request, orderedParamNameList):
     """


### PR DESCRIPTION
Revert the rmm spec from host req to runtime req. This was a technically incorrect change from #63 since rmm is a runtime requirement.