### PR TITLE
Bump to pytest-benchmark>=4.0.0.

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -16,12 +16,12 @@ requirements:
     host:
         - python
     run:
-        - python
-        - pytest-benchmark=3.2.3
-        - pynvml
         - asvdb>=0.3.0
-        - pygal
         - psutil
+        - pygal
+        - pynvml
+        - pytest-benchmark>=4.0.0
+        - python
         - rmm>=0.19.0a
 
 test:


### PR DESCRIPTION
Closes #65. Updates `pytest-benchmark` pinning to `>=4.0.0` for compatibility with `pytest>=7.2.0`.