### PR TITLE
makes histogram dependencies (pygal) optional, fixes ASV reporting bug, updates pytest-benchmark version pin

### DIFF
--- a/rapids_pytest_benchmark/conda/meta.yaml
+++ b/rapids_pytest_benchmark/conda/meta.yaml
@@ -16,12 +16,11 @@ requirements:
     host:
         - python
     run:
-        - python
-        - pytest-benchmark=3.2.3
-        - pynvml
         - asvdb>=0.3.0
-        - pygal
         - psutil
+        - pynvml
+        - pytest-benchmark>=3.2.3
+        - python
         - rmm>=0.19.0a
 
 test:

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/__init__.py
@@ -1,4 +1,17 @@
-__version__ = "0.0.14"
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.0.15"
 
 def setFixtureParamNames(request, orderedParamNameList):
     """

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/plugin.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import partial
 import time
 import platform
@@ -602,14 +615,15 @@ def pytest_sessionfinish(session, exitstatus):
 
             # If there were any custom metrics, add each of those as well as an
             # individual result to the same bInfo isntance.
-            for customMetricName in bench.stats.getCustomMetricNames():
-                (result, unitString) = bench.stats.getCustomMetric(customMetricName)
-                bn = "%s_%s" % (benchName, customMetricName)
-                bResult = BenchmarkResult(funcName=bn,
-                                          argNameValuePairs=list(params.items()),
-                                          result=result)
-                bResult.unit = unitString
-                resultList.append(bResult)
+            if isinstance(bench.stats, GPUStats):
+                for customMetricName in bench.stats.getCustomMetricNames():
+                    (result, unitString) = bench.stats.getCustomMetric(customMetricName)
+                    bn = "%s_%s" % (benchName, customMetricName)
+                    bResult = BenchmarkResult(funcName=bn,
+                                              argNameValuePairs=list(params.items()),
+                                              result=result)
+                    bResult.unit = unitString
+                    resultList.append(bResult)
 
             db.addResults(bInfo, resultList)
 

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/reporting.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/reporting.py
@@ -1,9 +1,21 @@
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import operator
 
 from pytest_benchmark import table as pytest_benchmark_table
 from pytest_benchmark import utils as pytest_benchmark_utils
-from pytest_benchmark import histogram as pytest_benchmark_histogram
 
 
 NUMBER_FMT = pytest_benchmark_table.NUMBER_FMT
@@ -160,6 +172,11 @@ class GPUTableResults(pytest_benchmark_table.TableResults):
             tr.write_line("-" * len(labels_line), yellow=True)
             tr.write_line("")
             if self.histogram:
+                # This import requires additional dependencies. Import it
+                # here so reporting that does not use the histogram feature
+                # need not install dependencies that will not be used.
+                from pytest_benchmark import histogram as pytest_benchmark_histogram
+
                 if len(benchmarks) > 75:
                     self.logger.warn("Group {0!r} has too many benchmarks. Only plotting 50 benchmarks.".format(group))
                     benchmarks = benchmarks[:75]

--- a/rapids_pytest_benchmark/rapids_pytest_benchmark/rmm_resource_analyzer.py
+++ b/rapids_pytest_benchmark/rapids_pytest_benchmark/rmm_resource_analyzer.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import csv
 import rmm

--- a/rapids_pytest_benchmark/setup.py
+++ b/rapids_pytest_benchmark/setup.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from setuptools import setup
 
 import rapids_pytest_benchmark

--- a/rapids_pytest_benchmark/setup.py
+++ b/rapids_pytest_benchmark/setup.py
@@ -6,7 +6,7 @@ setup(
         name="rapids-pytest-benchmark",
         version=rapids_pytest_benchmark.__version__,
         packages=["rapids_pytest_benchmark"],
-        install_requires=["pytest-benchmark", "asvdb", "pynvml", "pygal", "rmm"],
+        install_requires=["pytest-benchmark", "asvdb", "pynvml", "rmm"],
         # the following makes a plugin available to pytest
         entry_points={"pytest11": ["rapids_benchmark = rapids_pytest_benchmark.plugin"]},
         # custom PyPI classifier for pytest plugins


### PR DESCRIPTION
* Makes the dependencies needed for `--benchmark-histogram` optional (`pygal`), just as `pytest-benchmark` does
* Fixes a bug when writing ASV db output using a non-GPU stats object
* Updates the version pin for `pytest-benchmark` to allow newer versions (tested with `pytest-benchmark` 4.0.0)
* Updates version to `0.0.15`
* Adds copyright blocks
